### PR TITLE
burn after use

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -20,8 +20,9 @@ type TokenParser interface {
 type TokenIssuer func(context.Context, *TokenRequest) (string, error)
 
 type TokenResponse struct {
-	Token string `json:"token"`
-	Error string `json:"error,omitempty"`
+	Token        string `json:"token"`
+	BurnAfterUse bool   `json:"burn"`
+	Error        string `json:"error,omitempty"`
 }
 
 type Handler struct {
@@ -53,7 +54,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	tok, status, err := h.tokenRequest(ctx, r)
-	resp := TokenResponse{Token: tok}
+	resp := TokenResponse{
+		Token:        tok,
+		BurnAfterUse: true,
+	}
 	if err != nil {
 		h.log.Error(err, "error issuing token")
 		span.RecordError(err)

--- a/api/handler.go
+++ b/api/handler.go
@@ -20,9 +20,9 @@ type TokenParser interface {
 type TokenIssuer func(context.Context, *TokenRequest) (string, error)
 
 type TokenResponse struct {
-	Token        string `json:"token"`
-	BurnAfterUse bool   `json:"burn"`
-	Error        string `json:"error,omitempty"`
+	Token     string `json:"token"`
+	Revocable bool   `json:"revocable"`
+	Error     string `json:"error,omitempty"`
 }
 
 type Handler struct {
@@ -55,8 +55,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	tok, status, err := h.tokenRequest(ctx, r)
 	resp := TokenResponse{
-		Token:        tok,
-		BurnAfterUse: true,
+		Token:     tok,
+		Revocable: true,
 	}
 	if err != nil {
 		h.log.Error(err, "error issuing token")


### PR DESCRIPTION
I made the action revoke tokens after use.

Since there's a plausible future where cached tokens are returned, I'd prefer if the server gave specific instructions to the action that it is on them to burn the token.

